### PR TITLE
Don't overwrite properties on prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,11 @@ const knownProps = [
 ];
 
 module.exports = (fromStream, toStream) => {
-	const toProps = Object.keys(toStream);
 	const fromProps = new Set(Object.keys(fromStream).concat(knownProps));
 
 	for (const prop of fromProps) {
 		// Don't overwrite existing properties
-		if (toProps.indexOf(prop) !== -1) {
+		if (prop in toStream) {
 			continue;
 		}
 


### PR DESCRIPTION
If a property exists somewhere on the prototype chain of the `to` stream, it shouldn't be overwritten.

### Scenario

Say for instance the EventEmitter `on` function was patched directly on the `fromStream` instead of somewhere on its prototype chain. The string `"on"` would then be included in the `fromProps` and unless it was also present directly on the `toStream` object, it would be copied over. This probably wouldn't be such a big deal if it wasn't for the fact that the `on` function was being bound to the `fromStream`. This means that any event listeners added to the `toStream` would run in the context of the `fromStream`.

### Disclaimer

I don't know why the old code didn't look on the prototype chain. There might be a use-case where this makes sense that I just don't know about. If so, I'd be happy to see if I can find another solution 😃 
