### PR TITLE
Proxy events

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,12 @@ module.exports = (fromStream, toStream) => {
 
 	fromStream.once('close', () => {
 		if (fromStream.complete) {
-			if (toStream.readableEnded) {
-				toStream.emit('close');
-			} else {
+			if (toStream.readable) {
 				toStream.once('end', () => {
 					toStream.emit('close');
 				});
+			} else {
+				toStream.emit('close');
 			}
 		} else {
 			toStream.emit('close');

--- a/readme.md
+++ b/readme.md
@@ -48,34 +48,6 @@ myStream.destroy();
 
 Please note that `myStream` and `responseStream` never throws. The error is passed to the request instead.
 
-**Note #2:** The `aborted` and `close` events are not proxied. You have to add them manually:
-
-```js
-const stream = require('stream');
-const mimicResponse = require('mimic-response');
-
-const responseStream = getHttpResponseStream();
-const myStream = new stream.PassThrough({
-	destroy(error, callback) {
-		responseStream.destroy();
-
-		callback(error);
-	}
-});
-
-responseStream.once('aborted', () => {
-	myStream.destroy();
-
-	myStream.emit('aborted');
-});
-
-responseStream.once('closed', () => {
-	myStream.emit('closed');
-});
-
-responseStream.pipe(myStream);
-```
-
 #### from
 
 Type: `Stream`

--- a/test.js
+++ b/test.js
@@ -18,6 +18,14 @@ test.before(async () => {
 			response.end('sdf');
 		}, 2);
 	});
+
+	server.get('/aborted', (_request, response) => {
+		response.write('a');
+
+		setTimeout(() => {
+			response.socket.destroy();
+		}, 2);
+	});
 });
 
 test('normal', async t => {
@@ -27,7 +35,7 @@ test('normal', async t => {
 		return this;
 	};
 
-	const toStream = new stream.PassThrough();
+	const toStream = new stream.PassThrough({autoDestroy: false});
 	mimicResponse(response, toStream);
 
 	t.is(toStream.statusCode, 200);
@@ -53,7 +61,7 @@ test('do not overwrite prototype properties', async t => {
 		return origOn.call(this, name, handler);
 	};
 
-	const toStream = new stream.PassThrough();
+	const toStream = new stream.PassThrough({autoDestroy: false});
 	mimicResponse(response, toStream);
 
 	t.false(Object.keys(toStream).includes('on'));
@@ -66,4 +74,57 @@ test('do not overwrite prototype properties', async t => {
 	await pEvent(response, 'end');
 
 	t.true(toStream.complete);
+});
+
+test('`aborted` event', async t => {
+	const response = await pify(http.get, {errorFirst: false})(`${server.url}/aborted`);
+
+	const toStream = new stream.PassThrough({autoDestroy: false});
+	mimicResponse(response, toStream);
+
+	await pEvent(toStream, 'aborted');
+
+	t.true(toStream.destroyed);
+});
+
+test('autoDestroy must be false', async t => {
+	const response = await pify(http.get, {errorFirst: false})(`${server.url}/aborted`);
+
+	const toStream = new stream.PassThrough({autoDestroy: true});
+
+	t.throws(() => mimicResponse(response, toStream), {
+		message: 'The second stream must have the `autoDestroy` option set to `false`'
+	});
+});
+
+test('`close` event', async t => {
+	{
+		const response = await pify(http.get, {errorFirst: false})(server.url);
+
+		const toStream = new stream.PassThrough({autoDestroy: false});
+		mimicResponse(response, toStream);
+
+		response.pipe(toStream);
+		toStream.resume();
+
+		await pEvent(toStream, 'close');
+
+		t.true(response.readableEnded);
+		t.true(toStream.readableEnded);
+	}
+
+	{
+		const response = await pify(http.get, {errorFirst: false})(`${server.url}/aborted`);
+
+		const toStream = new stream.PassThrough({autoDestroy: false});
+		mimicResponse(response, toStream);
+
+		response.pipe(toStream);
+		toStream.resume();
+
+		await pEvent(toStream, 'close');
+
+		t.false(response.readableEnded);
+		t.false(toStream.readableEnded);
+	}
 });


### PR DESCRIPTION
I forgot to remove the `aborted` event proxy from my previous PR. The docs were a bit misleading. I've fixed it via placing `toStream.destroy()` before emitting the `aborted` event. Also fixed the docs.

Also added proxy for the `close` event.

I think this is a minor change (3.1.0) :sweat_smile: 